### PR TITLE
Show weekday labels in weekly stats chart

### DIFF
--- a/stats/script.js
+++ b/stats/script.js
@@ -446,7 +446,9 @@ document.addEventListener('DOMContentLoaded', () => {
         return Array.from({ length: 7 }, (_, i) => {
           const date = new Date(now);
           date.setDate(now.getDate() - (6 - i));
-          return date.getDate().toString();
+          let shortDay = date.toLocaleDateString(window.localization.getLocale(), { weekday: 'short' });
+          shortDay = shortDay.charAt(0).toUpperCase() + shortDay.slice(1);
+          return shortDay;
         });
       case 'month': {
         // Получаем данные за последний месяц (30 дней)


### PR DESCRIPTION
## Summary
- show short weekday names instead of numbers on the weekly chart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684324e22954832c9bbac363c4f69208