### PR TITLE
Fix weekday display only for month view

### DIFF
--- a/stats/utils.js
+++ b/stats/utils.js
@@ -19,11 +19,26 @@ function formatNumber(num) {
  * @returns {string} Отформатированная дата
  */
 function formatShortDate(date) {
-  return date.toLocaleDateString(window.localization.getLocale(), { 
-    day: 'numeric', 
-    month: 'short', 
-    year: 'numeric' 
+  return date.toLocaleDateString(window.localization.getLocale(), {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric'
   });
+}
+
+/**
+ * Форматирует дату в виде "пн, 9 апр. 2025"
+ * @param {Date} date Объект даты
+ * @returns {string} Отформатированная дата с днём недели
+ */
+function formatShortDateWithWeekday(date) {
+  const formatted = date.toLocaleDateString(window.localization.getLocale(), {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric'
+  });
+  return formatted.charAt(0).toUpperCase() + formatted.slice(1);
 }
 
 /**

--- a/stats/vertical-line.js
+++ b/stats/vertical-line.js
@@ -75,9 +75,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const currentPeriod = document.querySelector('.period-button.active')?.dataset.period || 'week';
         let formattedDate = '';
         
-        if (currentPeriod === 'week' || currentPeriod === 'month') {
-          // Для дня форматируем дату: 9 апр. 2025
+        if (currentPeriod === 'week') {
+          // Для дня в режиме недели: 9 апр. 2025
           formattedDate = formatShortDate(dateObj);
+        } else if (currentPeriod === 'month') {
+          // Для дня в режиме месяца показываем день недели
+          formattedDate = formatShortDateWithWeekday(dateObj);
         } else if (currentPeriod === '6month') {
           // Для недели вычисляем интервал: начальная дата + 6 дней
           formattedDate = formatWeekInterval(dateObj);


### PR DESCRIPTION
## Summary
- add dedicated `formatShortDateWithWeekday` helper
- restore original `formatShortDate` behaviour
- show weekday in long-press tooltip only for the month tab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845fdc660e4832c806ba8418e698bcf