### PR TITLE
Add info block factory

### DIFF
--- a/stats/block-factory.js
+++ b/stats/block-factory.js
@@ -1,0 +1,19 @@
+(function() {
+  const builders = [];
+
+  window.BlockFactory = {
+    register(builder) {
+      if (typeof builder === 'function') {
+        builders.push(builder);
+      }
+    },
+
+    buildAll(data, tdee) {
+      return builders.map(fn => fn(data, tdee)).join('');
+    },
+
+    clear() {
+      builders.length = 0;
+    }
+  };
+})();

--- a/stats/collections.js
+++ b/stats/collections.js
@@ -433,17 +433,18 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
   }
 
+  // Регистрируем функции построения блоков в фабрике
+  BlockFactory.register((data, tdee) => buildActiveBlock(data, tdee));
+  BlockFactory.register(() => buildStaticBlock(getWeekData()));
+  BlockFactory.register(() => buildMonthComparisonBlock());
+  BlockFactory.register(() => buildYearComparisonBlock());
+
   // Основная функция обновления инфо-блоков, объединяющая результаты всех блоков
   // Теперь эта функция лишь инициализирует все блоки при загрузке и обновляет только блок активности при переключении вкладок
   function updateCollections(data, tdee) {
-    // Всегда создаем все блоки заново при каждом вызове
-    const activeBlockHtml = buildActiveBlock(data, tdee);
-    const staticBlockHtml = buildStaticBlock(getWeekData());
-    const monthComparisonHtml = buildMonthComparisonBlock();
-    const yearComparisonHtml = buildYearComparisonBlock();
-
-    // Собираем HTML для всех блоков
-    collectionsContainer.innerHTML = activeBlockHtml + staticBlockHtml + monthComparisonHtml + yearComparisonHtml;
+    // Создаем HTML для всех блоков через фабрику
+    const html = BlockFactory.buildAll(data, tdee);
+    collectionsContainer.innerHTML = html;
 
     // Добавляем классы для идентификации блоков
     const blocks = collectionsContainer.querySelectorAll('.collection-card');

--- a/stats/index.html
+++ b/stats/index.html
@@ -463,6 +463,7 @@
   </div>
   <script src="localization.js"></script>
   <script src="utils.js"></script>
+  <script src="block-factory.js"></script>
   <script src="collections.js"></script>
   <script src="vertical-line.js"></script>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- add a simple BlockFactory module
- register info block builders and use factory when updating collections
- load the factory in statistics page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6861798fdda8832cbe26faf086154aa8