### PR TITLE
Add streak block to stats page

### DIFF
--- a/stats/collections.js
+++ b/stats/collections.js
@@ -433,11 +433,36 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
   }
 
+  function buildStreakBlock() {
+    const current = window.userCurrentStreak || 0;
+    const max = window.userMaxStreak || 0;
+
+    const currentText = window.localization.textCurrentStreak
+      .replace('{value}', formatNumber(current))
+      .replace('{unit}', window.localization.pluralizeDays(current));
+    const maxText = window.localization.textMaxStreak
+      .replace('{value}', formatNumber(max))
+      .replace('{unit}', window.localization.pluralizeDays(max));
+
+    return `
+      <div class="collection-card">
+        <div class="collection-header">
+          ${createFireIcon()}
+          <span class="collection-title">${window.localization.titleStreak}</span>
+        </div>
+        <div class="collection-text">
+          ${currentText}<br>${maxText}
+        </div>
+      </div>
+    `;
+  }
+
   // Регистрируем функции построения блоков в фабрике
   BlockFactory.register((data, tdee) => buildActiveBlock(data, tdee));
   BlockFactory.register(() => buildStaticBlock(getWeekData()));
   BlockFactory.register(() => buildMonthComparisonBlock());
   BlockFactory.register(() => buildYearComparisonBlock());
+  BlockFactory.register(() => buildStreakBlock());
 
   // Основная функция обновления инфо-блоков, объединяющая результаты всех блоков
   // Теперь эта функция лишь инициализирует все блоки при загрузке и обновляет только блок активности при переключении вкладок
@@ -451,6 +476,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (blocks.length >= 2) blocks[1].classList.add('static-calories-block');
     if (blocks.length >= 3) blocks[2].classList.add('month-comparison-block');
     if (blocks.length >= 4) blocks[3].classList.add('year-comparison-block');
+    if (blocks.length >= 5) blocks[4].classList.add('streak-block');
   }
 
   // Экспортируем функцию updateCollections в глобальную область видимости

--- a/stats/localization.js
+++ b/stats/localization.js
@@ -48,7 +48,10 @@
       // Новые ключи для спиннера и ошибки
       loading: "Загрузка...",
       loadingError: "Ошибка при загрузке данных",
-      retryButton: "Попробовать ещё раз"
+      retryButton: "Попробовать ещё раз",
+      titleStreak: "Серия без пропусков",
+      textCurrentStreak: "Текущая серия: {value} {unit}.",
+      textMaxStreak: "Максимальная серия: {value} {unit}."
     },
     en: {
       averageLabel: "Average<br>per day",
@@ -88,7 +91,10 @@
       // New keys for spinner and error
       loading: "Loading...",
       loadingError: "Error loading data",
-      retryButton: "Try again"
+      retryButton: "Try again",
+      titleStreak: "Streaks",
+      textCurrentStreak: "Current streak: {value} {unit}.",
+      textMaxStreak: "Max streak: {value} {unit}."
     },
     ar: {
       averageLabel: "متوسط<br>في اليوم",
@@ -126,7 +132,10 @@
       
       loading: "جارٍ التحميل...",
       loadingError: "خطأ في تحميل البيانات",
-      retryButton: "حاول مرة أخرى"
+      retryButton: "حاول مرة أخرى",
+      titleStreak: "سلسلة",
+      textCurrentStreak: "السلسلة الحالية: {value} {unit}.",
+      textMaxStreak: "أطول سلسلة: {value} {unit}."
     },
 
     de: {
@@ -165,7 +174,10 @@
       
       loading: "Laden...",
       loadingError: "Fehler beim Laden der Daten",
-      retryButton: "Erneut versuchen"
+      retryButton: "Erneut versuchen",
+      titleStreak: "Serie",
+      textCurrentStreak: "Aktuelle Serie: {value} {unit}.",
+      textMaxStreak: "Beste Serie: {value} {unit}."
     },
 
     es: {
@@ -204,7 +216,10 @@
       
       loading: "Cargando...",
       loadingError: "Error al cargar datos",
-      retryButton: "Intentar de nuevo"
+      retryButton: "Intentar de nuevo",
+      titleStreak: "Racha",
+      textCurrentStreak: "Racha actual: {value} {unit}.",
+      textMaxStreak: "Racha máxima: {value} {unit}."
     },
 
     fr: {
@@ -243,7 +258,10 @@
       
       loading: "Chargement...",
       loadingError: "Erreur de chargement des données",
-      retryButton: "Réessayer"
+      retryButton: "Réessayer",
+      titleStreak: "Série",
+      textCurrentStreak: "Série en cours : {value} {unit}.",
+      textMaxStreak: "Meilleure série : {value} {unit}."
     },
 
     hi: {
@@ -282,7 +300,10 @@
       
       loading: "लोड हो रहा है...",
       loadingError: "डेटा लोड करते समय त्रुटि",
-      retryButton: "पुनः प्रयास करें"
+      retryButton: "पुनः प्रयास करें",
+      titleStreak: "स्ट्रीक",
+      textCurrentStreak: "वर्तमान स्ट्रीक: {value} {unit}.",
+      textMaxStreak: "अधिकतम स्ट्रीक: {value} {unit}."
     },
 
     pt: {
@@ -321,7 +342,10 @@
       
       loading: "Carregando...",
       loadingError: "Erro ao carregar os dados",
-      retryButton: "Tentar novamente"
+      retryButton: "Tentar novamente",
+      titleStreak: "Sequência",
+      textCurrentStreak: "Sequência atual: {value} {unit}.",
+      textMaxStreak: "Máxima: {value} {unit}."
     },
 
     tr: {
@@ -360,7 +384,10 @@
       
       loading: "Yükleniyor...",
       loadingError: "Veriler yüklenirken hata oluştu",
-      retryButton: "Tekrar dene"
+      retryButton: "Tekrar dene",
+      titleStreak: "Seri",
+      textCurrentStreak: "Mevcut seri: {value} {unit}.",
+      textMaxStreak: "En uzun seri: {value} {unit}."
     },
 
     uk: {
@@ -399,7 +426,10 @@
       
       loading: "Завантаження...",
       loadingError: "Помилка завантаження даних",
-      retryButton: "Спробувати ще раз"
+      retryButton: "Спробувати ще раз",
+      titleStreak: "Серія",
+      textCurrentStreak: "Поточна серія: {value} {unit}.",
+      textMaxStreak: "Макс. серія: {value} {unit}."
     }
   };
 

--- a/stats/script.js
+++ b/stats/script.js
@@ -26,9 +26,13 @@ document.addEventListener('DOMContentLoaded', () => {
   if (debugMode) {
     window.allData = generateMockData(730);
     window.userTDEE = 2200; // Значение по умолчанию
+    window.userCurrentStreak = 5;
+    window.userMaxStreak = 10;
   } else {
     window.allData = [];
     window.userTDEE = 0; // Начальное значение
+    window.userCurrentStreak = 0;
+    window.userMaxStreak = 0;
   }
 
   // Если нужно показать индикатор загрузки, создаём затемнённый оверлей
@@ -142,6 +146,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // Преобразуем данные из Map<String, Int> в массив объектов {date, calories}
         const caloriesMap = responseData.calories;
         const tdee = responseData.tdee;
+        const currentStreak = responseData.currentStreak;
+        const maxStreak = responseData.maxStreak;
 
         const formattedData = [];
         // Рассчитываем даты за последние 730 дней для полного набора данных
@@ -171,6 +177,13 @@ document.addEventListener('DOMContentLoaded', () => {
         // Если TDEE известен, используем его, иначе оставляем значение по умолчанию
         if (tdee) {
           window.userTDEE = tdee;
+        }
+
+        if (typeof currentStreak === 'number') {
+          window.userCurrentStreak = currentStreak;
+        }
+        if (typeof maxStreak === 'number') {
+          window.userMaxStreak = maxStreak;
         }
 
         // Обновляем график после получения данных


### PR DESCRIPTION
## Summary
- parse current and max streak values from API
- track streak data globally
- display user streak info as a new collection card
- support streak texts in localization for multiple languages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863a35df5f8832ca8c8bc1db5f33c3b