### PR TITLE
Add optional goal toggle for BMR calculator

### DIFF
--- a/bmr/index.html
+++ b/bmr/index.html
@@ -106,7 +106,14 @@
         </div>
       </div>
         <div id="activityDescription" class="activity-description"></div>
-        <div class="form-group">
+        <div id="goal-toggle-group" class="form-group switch-group">
+          <label class="switch">
+            <input type="checkbox" id="goal-toggle">
+            <span class="slider"></span>
+          </label>
+          <label for="goal-toggle" id="label-goal-toggle" class="switch-label"></label>
+        </div>
+        <div id="goal-settings" class="form-group">
           <label class="field-label" id="label-goal"></label>
           <div class="radio-group">
             <div class="radio-option">

--- a/bmr/main.js
+++ b/bmr/main.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Female",
       labelActivity: "Physical Activity Level:",
       selectActivity: "Select level on the scale:",
+      goalToggleLabel: "Set goal (optional)",
       labelGoal: "Your goal:",
       goalSurplus: "Calorie surplus (mass gain)",
       goalDeficit: "Calorie deficit (weight loss)",
@@ -60,6 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Женский",
       labelActivity: "Уровень физической активности:",
       selectActivity: "Выберите уровень на шкале:",
+      goalToggleLabel: "Установить цель (опционально)",
       labelGoal: "Ваша цель:",
       goalSurplus: "Профицит калорий (набор массы)",
       goalDeficit: "Дефицит калорий (снижение веса)",
@@ -106,6 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "أنثى",
       labelActivity: "مستوى النشاط البدني:",
       selectActivity: "اختر المستوى على المقياس:",
+      goalToggleLabel: "تعيين هدف (اختياري)",
       labelGoal: "هدفك:",
       goalSurplus: "فائض السعرات (زيادة الكتلة)",
       goalDeficit: "عجز السعرات (فقدان الوزن)",
@@ -152,6 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Weiblich",
       labelActivity: "Körperliches Aktivitätsniveau:",
       selectActivity: "Wählen Sie den Level auf der Skala:",
+      goalToggleLabel: "Ziel festlegen (optional)",
       labelGoal: "Dein Ziel:",
       goalSurplus: "Kalorienüberschuss (Masseaufbau)",
       goalDeficit: "Kaloriendefizit (Gewichtsverlust)",
@@ -198,6 +202,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Mujer",
       labelActivity: "Nivel de actividad física:",
       selectActivity: "Seleccione el nivel en la escala:",
+      goalToggleLabel: "Establecer objetivo (opcional)",
       labelGoal: "Tu objetivo:",
       goalSurplus: "Superávit calórico (ganancia de masa)",
       goalDeficit: "Déficit calórico (pérdida de peso)",
@@ -244,6 +249,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Femme",
       labelActivity: "Niveau d'activité physique :",
       selectActivity: "Sélectionnez le niveau sur l'échelle :",
+      goalToggleLabel: "Définir l'objectif (optionnel)",
       labelGoal: "Votre objectif :",
       goalSurplus: "Surplus calorique (prise de masse)",
       goalDeficit: "Déficit calorique (perte de poids)",
@@ -290,6 +296,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "महिला",
       labelActivity: "शारीरिक गतिविधि का स्तर:",
       selectActivity: "स्केल पर स्तर चुनें:",
+      goalToggleLabel: "लक्ष्य सेट करें (वैकल्पिक)",
       labelGoal: "आपका लक्ष्य:",
       goalSurplus: "कैलोरी सरप्लस (वज़न बढ़ाना)",
       goalDeficit: "कैलोरी डेफिसिट (वज़न घटाना)",
@@ -336,6 +343,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Kadın",
       labelActivity: "Fiziksel Aktivite Seviyesi:",
       selectActivity: "Ölçekteki seviyeyi seçin:",
+      goalToggleLabel: "Hedef belirle (isteğe bağlı)",
       labelGoal: "Hedefiniz:",
       goalSurplus: "Kalori fazlası (kütle kazanımı)",
       goalDeficit: "Kalori açığı (kilo verme)",
@@ -382,6 +390,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Жіноча",
       labelActivity: "Рівень фізичної активності:",
       selectActivity: "Оберіть рівень на шкалі:",
+      goalToggleLabel: "Встановити ціль (опційно)",
       labelGoal: "Ваша мета:",
       goalSurplus: "Профіцит калорій (набір маси)",
       goalDeficit: "Дефіцит калорій (зниження ваги)",
@@ -428,6 +437,7 @@ document.addEventListener('DOMContentLoaded', () => {
       labelFemale: "Feminino",
       labelActivity: "Nível de Atividade Física:",
       selectActivity: "Selecione o nível na escala:",
+      goalToggleLabel: "Definir meta (opcional)",
       labelGoal: "Seu objetivo:",
       goalSurplus: "Superávit calórico (ganho de massa)",
       goalDeficit: "Déficit calórico (perda de peso)",
@@ -481,6 +491,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const activityRangeEl = document.getElementById('activityRange');
   activityRangeEl.addEventListener('input', updateActivityDescription);
   const activityDescriptionEl = document.getElementById('activityDescription');
+  const goalToggleEl = document.getElementById('goal-toggle');
+  const goalToggleLabelEl = document.getElementById('label-goal-toggle');
+  const goalSettingsEl = document.getElementById('goal-settings');
   const labelGoalEl = document.getElementById('label-goal');
   const goalSurplusLabelEl = document.getElementById('goal-surplus-label');
   const goalDeficitLabelEl = document.getElementById('goal-deficit-label');
@@ -490,6 +503,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const resultEl = document.getElementById('result');
   const tooltipBmrEl = document.getElementById('tooltip-bmr');
   const tooltipTdeeEl = document.getElementById('tooltip-tdee');
+
+  goalToggleEl.addEventListener('change', () => {
+    goalSettingsEl.style.display = goalToggleEl.checked ? 'block' : 'none';
+  });
 
   // Состояние
   const urlParams = new URLSearchParams(window.location.search || '');
@@ -532,6 +549,7 @@ document.addEventListener('DOMContentLoaded', () => {
     labelFemaleEl.innerText = t.labelFemale;
     labelActivityEl.innerText = t.labelActivity;
     selectActivityEl.innerText = t.selectActivity;
+    goalToggleLabelEl.innerText = t.goalToggleLabel;
     labelGoalEl.innerText = t.labelGoal;
     goalSurplusLabelEl.innerText = t.goalSurplus;
     goalDeficitLabelEl.innerText = t.goalDeficit;
@@ -662,6 +680,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const multipliers = [1.2, 1.375, 1.55, 1.725, 1.9];
     const tdee = bmr * multipliers[activityLevel - 1];
     
+    const goalInfo = goalToggleEl.checked ? {
+      type: document.querySelector('input[name="goal"]:checked')?.value || null,
+      value: (() => {
+        const val = parseFloat(goalValueEl.value);
+        return isNaN(val) ? null : val;
+      })()
+    } : null;
+
     const payload = {
       data: {
         height: height,
@@ -672,6 +698,7 @@ document.addEventListener('DOMContentLoaded', () => {
         bmr: Math.round(bmr),
         tdee: Math.round(tdee) // именно tdee, как было раньше
       },
+      goal: goalInfo,
       initData: window.Telegram.WebApp.initData
     };
 

--- a/bmr/style.css
+++ b/bmr/style.css
@@ -424,3 +424,65 @@ input::placeholder {
 .radio-option input[type="radio"]:hover {
   border-color: #006da1;
 }
+
+/* Стили для переключателя цели */
+.switch-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #666;
+  transition: 0.4s;
+  border-radius: 20px;
+}
+
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: #fff;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+  background-color: #0088cc;
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+.switch-label {
+  color: #fff;
+}
+
+/* Блок установки цели скрыт по умолчанию */
+#goal-settings {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- hide goal settings on load
- add switch button to reveal goal options
- localize toggle label for all languages
- include goal data in POST payload

## Testing
- `node --check bmr/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6864114f645c832c91f3e8b19324baef