### PR TITLE
Add goal streak stats

### DIFF
--- a/stats/collections.js
+++ b/stats/collections.js
@@ -433,9 +433,9 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
   }
 
-  function buildStreakBlock() {
-    const current = window.userCurrentStreak || 0;
-    const max = window.userMaxStreak || 0;
+  function buildLoggedStreakBlock() {
+    const current = window.userCurrentLoggedStreak || 0;
+    const max = window.userMaxLoggedStreak || 0;
 
     const currentText = window.localization.textCurrentStreak
       .replace('{value}', formatNumber(current))
@@ -457,12 +457,37 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
   }
 
+  function buildGoalStreakBlock() {
+    const current = window.userCurrentGoalStreak || 0;
+    const max = window.userMaxGoalStreak || 0;
+
+    const currentText = window.localization.textCurrentGoalStreak
+      .replace('{value}', formatNumber(current))
+      .replace('{unit}', window.localization.pluralizeDays(current));
+    const maxText = window.localization.textMaxGoalStreak
+      .replace('{value}', formatNumber(max))
+      .replace('{unit}', window.localization.pluralizeDays(max));
+
+    return `
+      <div class="collection-card">
+        <div class="collection-header">
+          ${createFireIcon()}
+          <span class="collection-title">${window.localization.titleGoalStreak}</span>
+        </div>
+        <div class="collection-text">
+          ${currentText}<br>${maxText}
+        </div>
+      </div>
+    `;
+  }
+
   // Регистрируем функции построения блоков в фабрике
   BlockFactory.register((data, tdee) => buildActiveBlock(data, tdee));
   BlockFactory.register(() => buildStaticBlock(getWeekData()));
   BlockFactory.register(() => buildMonthComparisonBlock());
   BlockFactory.register(() => buildYearComparisonBlock());
-  BlockFactory.register(() => buildStreakBlock());
+  BlockFactory.register(() => buildLoggedStreakBlock());
+  BlockFactory.register(() => buildGoalStreakBlock());
 
   // Основная функция обновления инфо-блоков, объединяющая результаты всех блоков
   // Теперь эта функция лишь инициализирует все блоки при загрузке и обновляет только блок активности при переключении вкладок
@@ -477,6 +502,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (blocks.length >= 3) blocks[2].classList.add('month-comparison-block');
     if (blocks.length >= 4) blocks[3].classList.add('year-comparison-block');
     if (blocks.length >= 5) blocks[4].classList.add('streak-block');
+    if (blocks.length >= 6) blocks[5].classList.add('goal-streak-block');
   }
 
   // Экспортируем функцию updateCollections в глобальную область видимости

--- a/stats/index.html
+++ b/stats/index.html
@@ -227,6 +227,18 @@
       border-radius: 8px;
       color: var(--text-color);
     }
+    .collection-card.streak-block,
+    .collection-card.goal-streak-block {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .streak-block .collection-text,
+    .goal-streak-block .collection-text {
+      margin-bottom: 0;
+      font-size: 16px;
+      text-align: right;
+    }
     .collection-header {
       display: flex;
       align-items: center;

--- a/stats/localization.js
+++ b/stats/localization.js
@@ -51,7 +51,10 @@
       retryButton: "Попробовать ещё раз",
       titleStreak: "Серия без пропусков",
       textCurrentStreak: "Текущая серия: {value} {unit}.",
-      textMaxStreak: "Максимальная серия: {value} {unit}."
+      textMaxStreak: "Максимальная серия: {value} {unit}.",
+      titleGoalStreak: "Серия выполнения цели",
+      textCurrentGoalStreak: "Текущая серия: {value} {unit}.",
+      textMaxGoalStreak: "Максимальная серия: {value} {unit}."
     },
     en: {
       averageLabel: "Average<br>per day",
@@ -94,7 +97,10 @@
       retryButton: "Try again",
       titleStreak: "Streaks",
       textCurrentStreak: "Current streak: {value} {unit}.",
-      textMaxStreak: "Max streak: {value} {unit}."
+      textMaxStreak: "Max streak: {value} {unit}.",
+      titleGoalStreak: "Goal streak",
+      textCurrentGoalStreak: "Current goal streak: {value} {unit}.",
+      textMaxGoalStreak: "Max goal streak: {value} {unit}."
     },
     ar: {
       averageLabel: "متوسط<br>في اليوم",
@@ -135,7 +141,10 @@
       retryButton: "حاول مرة أخرى",
       titleStreak: "سلسلة",
       textCurrentStreak: "السلسلة الحالية: {value} {unit}.",
-      textMaxStreak: "أطول سلسلة: {value} {unit}."
+      textMaxStreak: "أطول سلسلة: {value} {unit}.",
+      titleGoalStreak: "سلسلة الهدف",
+      textCurrentGoalStreak: "السلسلة الحالية: {value} {unit}.",
+      textMaxGoalStreak: "أطول سلسلة: {value} {unit}."
     },
 
     de: {
@@ -177,7 +186,10 @@
       retryButton: "Erneut versuchen",
       titleStreak: "Serie",
       textCurrentStreak: "Aktuelle Serie: {value} {unit}.",
-      textMaxStreak: "Beste Serie: {value} {unit}."
+      textMaxStreak: "Beste Serie: {value} {unit}.",
+      titleGoalStreak: "Ziel-Serie",
+      textCurrentGoalStreak: "Aktuelle Serie: {value} {unit}.",
+      textMaxGoalStreak: "Beste Serie: {value} {unit}."
     },
 
     es: {
@@ -219,7 +231,10 @@
       retryButton: "Intentar de nuevo",
       titleStreak: "Racha",
       textCurrentStreak: "Racha actual: {value} {unit}.",
-      textMaxStreak: "Racha máxima: {value} {unit}."
+      textMaxStreak: "Racha máxima: {value} {unit}.",
+      titleGoalStreak: "Racha de objetivo",
+      textCurrentGoalStreak: "Racha actual: {value} {unit}.",
+      textMaxGoalStreak: "Racha máxima: {value} {unit}."
     },
 
     fr: {
@@ -261,7 +276,10 @@
       retryButton: "Réessayer",
       titleStreak: "Série",
       textCurrentStreak: "Série en cours : {value} {unit}.",
-      textMaxStreak: "Meilleure série : {value} {unit}."
+      textMaxStreak: "Meilleure série : {value} {unit}.",
+      titleGoalStreak: "Série d'objectif",
+      textCurrentGoalStreak: "Série en cours : {value} {unit}.",
+      textMaxGoalStreak: "Meilleure série : {value} {unit}."
     },
 
     hi: {
@@ -303,7 +321,10 @@
       retryButton: "पुनः प्रयास करें",
       titleStreak: "स्ट्रीक",
       textCurrentStreak: "वर्तमान स्ट्रीक: {value} {unit}.",
-      textMaxStreak: "अधिकतम स्ट्रीक: {value} {unit}."
+      textMaxStreak: "अधिकतम स्ट्रीक: {value} {unit}.",
+      titleGoalStreak: "लक्ष्य स्ट्रीक",
+      textCurrentGoalStreak: "वर्तमान स्ट्रीक: {value} {unit}.",
+      textMaxGoalStreak: "अधिकतम स्ट्रीक: {value} {unit}."
     },
 
     pt: {
@@ -345,7 +366,10 @@
       retryButton: "Tentar novamente",
       titleStreak: "Sequência",
       textCurrentStreak: "Sequência atual: {value} {unit}.",
-      textMaxStreak: "Máxima: {value} {unit}."
+      textMaxStreak: "Máxima: {value} {unit}.",
+      titleGoalStreak: "Sequência da meta",
+      textCurrentGoalStreak: "Sequência atual: {value} {unit}.",
+      textMaxGoalStreak: "Máxima: {value} {unit}."
     },
 
     tr: {
@@ -387,7 +411,10 @@
       retryButton: "Tekrar dene",
       titleStreak: "Seri",
       textCurrentStreak: "Mevcut seri: {value} {unit}.",
-      textMaxStreak: "En uzun seri: {value} {unit}."
+      textMaxStreak: "En uzun seri: {value} {unit}.",
+      titleGoalStreak: "Hedef serisi",
+      textCurrentGoalStreak: "Mevcut seri: {value} {unit}.",
+      textMaxGoalStreak: "En uzun seri: {value} {unit}."
     },
 
     uk: {
@@ -429,7 +456,10 @@
       retryButton: "Спробувати ще раз",
       titleStreak: "Серія",
       textCurrentStreak: "Поточна серія: {value} {unit}.",
-      textMaxStreak: "Макс. серія: {value} {unit}."
+      textMaxStreak: "Макс. серія: {value} {unit}.",
+      titleGoalStreak: "Серія виконання мети",
+      textCurrentGoalStreak: "Поточна серія: {value} {unit}.",
+      textMaxGoalStreak: "Макс. серія: {value} {unit}."
     }
   };
 

--- a/stats/script.js
+++ b/stats/script.js
@@ -26,13 +26,17 @@ document.addEventListener('DOMContentLoaded', () => {
   if (debugMode) {
     window.allData = generateMockData(730);
     window.userTDEE = 2200; // Значение по умолчанию
-    window.userCurrentStreak = 5;
-    window.userMaxStreak = 10;
+    window.userCurrentLoggedStreak = 5;
+    window.userMaxLoggedStreak = 10;
+    window.userCurrentGoalStreak = 3;
+    window.userMaxGoalStreak = 7;
   } else {
     window.allData = [];
     window.userTDEE = 0; // Начальное значение
-    window.userCurrentStreak = 0;
-    window.userMaxStreak = 0;
+    window.userCurrentLoggedStreak = 0;
+    window.userMaxLoggedStreak = 0;
+    window.userCurrentGoalStreak = 0;
+    window.userMaxGoalStreak = 0;
   }
 
   // Если нужно показать индикатор загрузки, создаём затемнённый оверлей
@@ -146,8 +150,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // Преобразуем данные из Map<String, Int> в массив объектов {date, calories}
         const caloriesMap = responseData.calories;
         const tdee = responseData.tdee;
-        const currentStreak = responseData.currentStreak;
-        const maxStreak = responseData.maxStreak;
+        const currentLoggedStreak = responseData.currentLoggedDaysStreak;
+        const maxLoggedStreak = responseData.maxLoggedDaysStreak;
+        const currentGoalStreak = responseData.currentGoalStreak;
+        const maxGoalStreak = responseData.maxGoalStreak;
 
         const formattedData = [];
         // Рассчитываем даты за последние 730 дней для полного набора данных
@@ -179,11 +185,17 @@ document.addEventListener('DOMContentLoaded', () => {
           window.userTDEE = tdee;
         }
 
-        if (typeof currentStreak === 'number') {
-          window.userCurrentStreak = currentStreak;
+        if (typeof currentLoggedStreak === 'number') {
+          window.userCurrentLoggedStreak = currentLoggedStreak;
         }
-        if (typeof maxStreak === 'number') {
-          window.userMaxStreak = maxStreak;
+        if (typeof maxLoggedStreak === 'number') {
+          window.userMaxLoggedStreak = maxLoggedStreak;
+        }
+        if (typeof currentGoalStreak === 'number') {
+          window.userCurrentGoalStreak = currentGoalStreak;
+        }
+        if (typeof maxGoalStreak === 'number') {
+          window.userMaxGoalStreak = maxGoalStreak;
         }
 
         // Обновляем график после получения данных


### PR DESCRIPTION
## Summary
- support new API fields for streak data
- display logged streak and goal streak blocks
- style streak blocks in stats page
- localize goal streak strings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866c4a06d60832cbe82a7b74782c618