### PR TITLE
Fix progress label clipping

### DIFF
--- a/stats/index.html
+++ b/stats/index.html
@@ -285,7 +285,7 @@
       position: absolute;
       top: 0;
       left: 0;
-      overflow: hidden;
+      overflow: visible;
     }
     .progress-container .period-bar.background {
       width: 100%;
@@ -302,7 +302,7 @@
       border-radius: 6px;
       margin-bottom: 8px;
       position: relative;
-      overflow: hidden;
+      overflow: visible;
     }
     .comparison-bar.current {
       background: var(--orange-accent);


### PR DESCRIPTION
## Summary
- ensure progress text is visible even when the bar is narrow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686baeb6ea48832c8a326166ed725815