### PR TITLE
Add localized short form for days

### DIFF
--- a/stats/collections.js
+++ b/stats/collections.js
@@ -441,10 +441,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const currentText = window.localization.textCurrentStreak
       .replace('{value}', `<strong>${formatNumber(current)}</strong>`)
-      .replace('{unit}', `<strong>${window.localization.pluralizeDays(current)}</strong>`);
+      .replace('{unit}', `<strong>${window.localization.getDayShort()}</strong>`);
     const maxText = window.localization.textMaxStreak
       .replace('{value}', `<strong>${formatNumber(max)}</strong>`)
-      .replace('{unit}', `<strong>${window.localization.pluralizeDays(max)}</strong>`);
+      .replace('{unit}', `<strong>${window.localization.getDayShort()}</strong>`);
 
     const safeMax = max > 0 ? max : 1;
     const rawPercent = (current / safeMax) * 100;
@@ -474,10 +474,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const currentText = window.localization.textCurrentGoalStreak
       .replace('{value}', `<strong>${formatNumber(current)}</strong>`)
-      .replace('{unit}', `<strong>${window.localization.pluralizeDays(current)}</strong>`);
+      .replace('{unit}', `<strong>${window.localization.getDayShort()}</strong>`);
     const maxText = window.localization.textMaxGoalStreak
       .replace('{value}', `<strong>${formatNumber(max)}</strong>`)
-      .replace('{unit}', `<strong>${window.localization.pluralizeDays(max)}</strong>`);
+      .replace('{unit}', `<strong>${window.localization.getDayShort()}</strong>`);
 
     const safeMax = max > 0 ? max : 1;
     const rawPercent = (current / safeMax) * 100;

--- a/stats/localization.js
+++ b/stats/localization.js
@@ -17,6 +17,7 @@
       noData: "Нет данных",
       dailyKcalLabel: "ккал в день",
       tdeeThreshold: "TDEE",
+      dayShort: "д.",
       
       titleStaticCalories: "За последние 7 дней",
       textStaticCalories: "В среднем за последние 7 дней Вы потребляли {value} ккал в день.",
@@ -61,6 +62,7 @@
       kilocalories: "kcal",
       noData: "No data",
       dailyKcalLabel: "kcal/day",
+      dayShort: "d.",
       tdeeThreshold: "TDEE",
       
       titleStaticCalories: "Last 7 days",
@@ -106,6 +108,7 @@
       averageLabel: "متوسط<br>في اليوم",
       kilocalories: "سعرة حرارية",
       noData: "لا توجد بيانات",
+      dayShort: "ي.",
       dailyKcalLabel: "سعرة/اليوم",
       tdeeThreshold: "TDEE",
       
@@ -153,6 +156,7 @@
       noData: "Keine Daten",
       dailyKcalLabel: "kcal/Tag",
       tdeeThreshold: "TDEE",
+      dayShort: "T.",
       
       titleStaticCalories: "Letzte 7 Tage",
       textStaticCalories: "In den letzten 7 Tagen haben Sie durchschnittlich {value} kcal pro Tag konsumiert.",
@@ -198,6 +202,7 @@
       noData: "No hay datos",
       dailyKcalLabel: "kcal/día",
       tdeeThreshold: "TDEE",
+      dayShort: "d.",
       
       titleStaticCalories: "Últimos 7 días",
       textStaticCalories: "En promedio, durante los últimos 7 días, consumiste {value} kcal por día.",
@@ -243,6 +248,7 @@
       noData: "Pas de données",
       dailyKcalLabel: "kcal/jour",
       tdeeThreshold: "TDEE",
+      dayShort: "j.",
       
       titleStaticCalories: "7 derniers jours",
       textStaticCalories: "En moyenne, au cours des 7 derniers jours, vous avez consommé {value} kcal par jour.",
@@ -288,6 +294,7 @@
       noData: "कोई डेटा नहीं",
       dailyKcalLabel: "कैलोरी/दिन",
       tdeeThreshold: "TDEE",
+      dayShort: "दि.",
       
       titleStaticCalories: "पिछले 7 दिन",
       textStaticCalories: "पिछले 7 दिनों में औसतन, आपने {value} कैलोरी प्रति दिन उपभोग की हैं।",
@@ -333,6 +340,7 @@
       noData: "Nenhum dado",
       dailyKcalLabel: "kcal/dia",
       tdeeThreshold: "TDEE",
+      dayShort: "d.",
       
       titleStaticCalories: "Últimos 7 dias",
       textStaticCalories: "Em média, nos últimos 7 dias, você consumiu {value} kcal por dia.",
@@ -378,6 +386,7 @@
       noData: "Veri yok",
       dailyKcalLabel: "kcal/gün",
       tdeeThreshold: "TDEE",
+      dayShort: "g.",
       
       titleStaticCalories: "Son 7 gün",
       textStaticCalories: "Son 7 günde ortalama olarak günde {value} kcal tükettiniz.",
@@ -423,6 +432,7 @@
       noData: "Немає даних",
       dailyKcalLabel: "ккал/день",
       tdeeThreshold: "TDEE",
+      dayShort: "д.",
       
       titleStaticCalories: "Останні 7 днів",
       textStaticCalories: "У середньому за останні 7 днів Ви споживали {value} ккал на день.",
@@ -472,6 +482,11 @@
   // Функция для получения локали для Intl.NumberFormat и date.toLocaleString
   window.localization.getLocale = function() {
     return window.localization._lang || 'en';
+  };
+
+  // Возвращает сокращённую форму слова "день" для текущей локали
+  window.localization.getDayShort = function() {
+    return localizations[window.localization._lang]?.dayShort || 'd.';
   };
 
   /**


### PR DESCRIPTION
## Summary
- support per-language abbreviation of "day" via `dayShort`
- display streak units using short form

## Testing
- `node --check stats/localization.js`
- `node --check stats/collections.js`


------
https://chatgpt.com/codex/tasks/task_e_686bc642c04c832ca6c215deac7358aa