### PR TITLE
Adjust streak text font

### DIFF
--- a/stats/collections.js
+++ b/stats/collections.js
@@ -456,7 +456,8 @@ document.addEventListener('DOMContentLoaded', () => {
           <span class="collection-title">${window.localization.titleStreak}</span>
         </div>
         <div class="collection-text">
-          ${currentText}<br>${maxText}
+          <span class="streak-text">${currentText}</span><br>
+          <span class="streak-text">${maxText}</span>
         </div>
         <div class="progress-container">
           <div class="period-bar background"></div>
@@ -489,7 +490,8 @@ document.addEventListener('DOMContentLoaded', () => {
           <span class="collection-title">${window.localization.titleGoalStreak}</span>
         </div>
         <div class="collection-text">
-          ${currentText}<br>${maxText}
+          <span class="streak-text">${currentText}</span><br>
+          <span class="streak-text">${maxText}</span>
         </div>
         <div class="progress-container">
           <div class="period-bar background"></div>

--- a/stats/index.html
+++ b/stats/index.html
@@ -261,6 +261,9 @@
       line-height: 1.4;
       margin-bottom: 16px;
     }
+    .collection-text .streak-text {
+      font-size: 13px;
+    }
     .collection-period {
       margin-top: 8px;
     }


### PR DESCRIPTION
## Summary
- tweak `collection-text` style to reduce font size for streak lines
- wrap streak texts in `streak-text` spans for both logged and goal streak cards

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c455b524c832cb1208fd6587129ac