### PR TITLE
Shorten Russian max streak label

### DIFF
--- a/stats/localization.js
+++ b/stats/localization.js
@@ -52,10 +52,10 @@
       retryButton: "Попробовать ещё раз",
       titleStreak: "Серия без пропусков",
       textCurrentStreak: "Текущая серия: {value} {unit}.",
-      textMaxStreak: "Максимальная серия: {value} {unit}.",
+      textMaxStreak: "Макс. серия: {value} {unit}.",
       titleGoalStreak: "Серия выполнения цели",
       textCurrentGoalStreak: "Текущая серия: {value} {unit}.",
-      textMaxGoalStreak: "Максимальная серия: {value} {unit}."
+      textMaxGoalStreak: "Макс. серия: {value} {unit}."
     },
     en: {
       averageLabel: "Average<br>per day",


### PR DESCRIPTION
## Summary
- shorten RU streak labels to "Макс. серия" to keep the card text on one line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c583589cc832ca391f82b38c883af