### PR TITLE
Fix streak icon size

### DIFF
--- a/stats/index.html
+++ b/stats/index.html
@@ -239,6 +239,10 @@
     .streak-row .collection-title {
       font-size: 14px;
     }
+    .streak-row .collection-icon {
+      width: 24px;
+      height: 24px;
+    }
 
     .collection-header {
       display: flex;


### PR DESCRIPTION
## Summary
- ensure streak headers use normal icon dimensions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876a1da6b74832ca6a090397c385a98