### PR TITLE
Fix streak icon size

### DIFF
--- a/stats/index.html
+++ b/stats/index.html
@@ -239,6 +239,10 @@
     .streak-row .collection-title {
       font-size: 14px;
     }
+    .streak-row .collection-icon {
+      width: 24px;
+      height: 24px;
+    }
 
     .collection-header {
       display: flex;
@@ -250,6 +254,7 @@
       height: 24px;
       margin-right: 8px;
       color: var(--orange-accent);
+      flex-shrink: 0;
     }
     .collection-title {
       color: var(--orange-accent);


### PR DESCRIPTION
## Summary
- ensure header icons do not shrink in streak blocks

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876a1da6b74832ca6a090397c385a98