### PR TITLE
Set default deficit goal when toggled

### DIFF
--- a/bmr/main.js
+++ b/bmr/main.js
@@ -503,6 +503,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const tooltipTdeeEl = document.getElementById('tooltip-tdee');
 
   goalToggleEl.addEventListener('change', () => {
+    if (goalToggleEl.checked) {
+      // При активации свитча по умолчанию выбираем дефицит калорий
+      document.getElementById('goal-deficit').checked = true;
+    } else {
+      // При выключении свитча сбрасываем выбор цели
+      document.querySelectorAll('input[name="goal"]').forEach(el => el.checked = false);
+    }
     goalSettingsEl.style.display = goalToggleEl.checked ? 'block' : 'none';
   });
 


### PR DESCRIPTION
## Summary
- make calories deficit goal selected when enabling goal switch
- clear goal selection when disabling the switch

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6876daf48818832c9628f8f6d9b4f57e