### PR TITLE
[codex] Point miniapp API to caloriesai backend

### DIFF
--- a/bmr/index.html
+++ b/bmr/index.html
@@ -145,6 +145,7 @@
       <div id="result"></div>
   </div>
   
+  <script src="../config.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/bmr/main.js
+++ b/bmr/main.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const API_BASE_URL = window.CaloriesMiniAppConfig?.apiBaseUrl || 'https://caloriesai.duckdns.org';
+
   // Поддерживаемые локали
   const supportedLocales = ["ar", "de", "es", "fr", "hi", "ru", "tr", "uk", "en"];
   
@@ -776,7 +778,7 @@ document.addEventListener('DOMContentLoaded', () => {
     resultEl.classList.add('visible');
     
     try {
-      const response = await fetch('https://calories-bot.duckdns.org/bot/mbr', {
+      const response = await fetch(`${API_BASE_URL}/bot/mbr`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/config.js
+++ b/config.js
@@ -1,0 +1,10 @@
+(function () {
+  const defaultConfig = {
+    apiBaseUrl: 'https://caloriesai.duckdns.org'
+  };
+
+  window.CaloriesMiniAppConfig = Object.assign(
+    defaultConfig,
+    window.CaloriesMiniAppConfig || {}
+  );
+})();

--- a/edit/index.html
+++ b/edit/index.html
@@ -195,7 +195,8 @@
     </div>
   </div>
   
+  <script src="../config.js"></script>
   <script src="main.js"></script>
   <script src="script.js" defer></script>
 </body>
-</html> 
+</html>

--- a/edit/script.js
+++ b/edit/script.js
@@ -9,6 +9,7 @@
   const editSection = document.getElementById('editSection');
   const caloriesInput = document.getElementById('caloriesInput');
   const loadingElement = document.getElementById('loading');
+  const API_BASE_URL = window.CaloriesMiniAppConfig?.apiBaseUrl || 'https://caloriesai.duckdns.org';
 
   // Состояние
   let currentDate = new Date();
@@ -88,7 +89,7 @@
       };
       console.log('Отправляем запрос:', JSON.stringify(requestBody));
       
-      const response = await fetch('https://calories-bot.duckdns.org/api/calories', {
+      const response = await fetch(`${API_BASE_URL}/api/calories`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -144,7 +145,7 @@
       };
       console.log('Отправляем запрос на обновление:', JSON.stringify(requestBody));
       
-      const response = await fetch('https://calories-bot.duckdns.org/api/edit', {
+      const response = await fetch(`${API_BASE_URL}/api/edit`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -386,4 +387,4 @@ window.addEventListener('resize', () => {
   
   // Запускаем приложение
   init();
-})(); 
+})();

--- a/history/index.html
+++ b/history/index.html
@@ -114,6 +114,7 @@
     </li>
   </template>
 
+  <script src="../config.js"></script>
   <script src="localization.js"></script>
   <script type="module" src="script.js"></script>
 </body>

--- a/history/script.js
+++ b/history/script.js
@@ -39,7 +39,10 @@ if (tg) {
   tg.onEvent('themeChanged', () => applyTheme(tg.themeParams, tg.colorScheme));
 }
 
-const API_BASE_URL = window.__CALORIES_HISTORY_API_BASE__ || 'https://calories-bot.duckdns.org';
+const API_BASE_URL =
+  window.__CALORIES_HISTORY_API_BASE__ ||
+  window.CaloriesMiniAppConfig?.apiBaseUrl ||
+  'https://caloriesai.duckdns.org';
 
 const historyState = {
   days: [],

--- a/stats/index.html
+++ b/stats/index.html
@@ -573,6 +573,7 @@
     </a>
   </nav>
 
+  <script src="../config.js"></script>
   <script src="localization.js"></script>
   <script src="utils.js"></script>
   <script src="block-factory.js"></script>

--- a/stats/script.js
+++ b/stats/script.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   // Инициализация Telegram WebApp
   const tg = window.Telegram.WebApp;
+  const API_BASE_URL = window.CaloriesMiniAppConfig?.apiBaseUrl || 'https://caloriesai.duckdns.org';
   tg.ready();
   tg.expand();
 
@@ -123,7 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Получаем таймзону пользователя
         const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         
-        const response = await fetch('https://calories-bot.duckdns.org/api/stats', {
+        const response = await fetch(`${API_BASE_URL}/api/stats`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## What changed

- Adds a shared `config.js` for Mini App runtime settings.
- Points Mini App backend API calls to `https://caloriesai.duckdns.org`.
- Wires the shared config into BMR, editor, stats, and history pages.

## Why

The Mini App continues to be hosted by GitHub Pages, but its backend API now needs to go through the replacement domain served by nginx on the new host.

## Validation

- `node --check config.js`
- `node --check bmr/main.js`
- `node --check edit/main.js`
- `node --check edit/script.js`
- `node --check stats/script.js`
- `node --check history/script.js`
- `rg "calories-bot\\.duckdns\\.org|89\\.110|8443|9968" . -S` returns no matches
- `git diff --cached --check`
