### PR TITLE
fix(profile): выбор времени напоминания кнопкой (iOS overflow)

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -89,8 +89,17 @@
       <p class="modal__description" data-rem-i18n="modalDescription">Выберите время и тип напоминания.</p>
 
       <div class="modal__field">
-        <label class="modal__label" for="reminders-modal-time" data-rem-i18n="modalTimeLabel">Время</label>
-        <input class="modal__input" id="reminders-modal-time" type="time" required>
+        <span class="modal__label" id="reminders-modal-time-label" data-rem-i18n="modalTimeLabel">Время</span>
+        <!--
+          Нативный input[type=time] под iOS рендерится широким и вылезал за
+          границы модалки (#615). Прячем его как источник значения для нативного
+          пикера, а видимый контрол — кнопка, открывающая пикер по клику.
+        -->
+        <button type="button" class="modal__time-button" id="reminders-modal-time-button"
+                aria-labelledby="reminders-modal-time-label"
+                data-rem-i18n="modalTimePlaceholder">Выбрать время</button>
+        <input class="modal__time-input" id="reminders-modal-time" type="time" required
+               tabindex="-1" aria-hidden="true">
       </div>
 
       <div class="modal__field">

--- a/profile/reminders.js
+++ b/profile/reminders.js
@@ -39,6 +39,7 @@
       modalTitle: 'Новое напоминание',
       modalDescription: 'Выберите время и тип напоминания.',
       modalTimeLabel: 'Время',
+      modalTimePlaceholder: 'Выбрать время',
       modalTypeLabel: 'Тип',
       typeAriaLabel: 'Тип напоминания',
       cancel: 'Отмена',
@@ -66,6 +67,7 @@
       modalTitle: 'New reminder',
       modalDescription: 'Choose a time and reminder type.',
       modalTimeLabel: 'Time',
+      modalTimePlaceholder: 'Choose time',
       modalTypeLabel: 'Type',
       typeAriaLabel: 'Reminder type',
       cancel: 'Cancel',
@@ -129,6 +131,7 @@
     locale = normalized;
     STR = TRANSLATIONS[locale];
     applyI18n();
+    syncTimeButton();
     render();
     refreshTypeAvailability();
   }
@@ -145,6 +148,7 @@
     modal: document.getElementById('reminders-modal'),
     modalForm: document.getElementById('reminders-modal-form'),
     modalTime: document.getElementById('reminders-modal-time'),
+    modalTimeButton: document.getElementById('reminders-modal-time-button'),
     modalTypes: document.getElementById('reminders-modal-types'),
     modalError: document.getElementById('reminders-modal-error'),
     modalSubmit: null,
@@ -291,6 +295,39 @@
     });
   }
 
+  // Синхронизируем текст кнопки времени с текущим значением инпута: выбранное
+  // время — основным цветом (модификатор --filled), иначе плейсхолдер локали.
+  function syncTimeButton() {
+    const time = normalizeTime(els.modalTime.value);
+    if (time) {
+      els.modalTimeButton.textContent = time;
+      els.modalTimeButton.classList.add('modal__time-button--filled');
+    } else {
+      els.modalTimeButton.textContent = STR.modalTimePlaceholder;
+      els.modalTimeButton.classList.remove('modal__time-button--filled');
+    }
+  }
+
+  // Открываем нативный пикер времени. showPicker() — предпочтительный путь
+  // (Safari iOS 16+/современные браузеры); в старых или при ошибке падаем на
+  // focus()+click(), чтобы барабан времени всё равно поднялся.
+  function openTimePicker() {
+    try {
+      if (typeof els.modalTime.showPicker === 'function') {
+        els.modalTime.showPicker();
+        return;
+      }
+    } catch (_) {
+      void 0;
+    }
+    try {
+      els.modalTime.focus();
+      els.modalTime.click();
+    } catch (_) {
+      void 0;
+    }
+  }
+
   function clearModalError() {
     els.modalError.hidden = true;
     els.modalError.textContent = '';
@@ -350,6 +387,7 @@
     else if (canAdd('EVENING')) setSelectedType('EVENING');
 
     els.modalTime.value = '';
+    syncTimeButton();
     showModal(els.modal);
   }
 
@@ -510,6 +548,15 @@
   // Привязка обработчиков модалки / кнопок.
   els.add.addEventListener('click', handleAddClick);
   els.modalForm.addEventListener('submit', handleModalSubmit);
+
+  // Кнопка открывает нативный пикер; выбранное значение прилетает событиями
+  // change/input на скрытом инпуте и отражается на тексте кнопки.
+  els.modalTimeButton.addEventListener('click', () => {
+    clearModalError();
+    openTimePicker();
+  });
+  els.modalTime.addEventListener('change', syncTimeButton);
+  els.modalTime.addEventListener('input', syncTimeButton);
 
   els.modalTypes.addEventListener('click', (event) => {
     const btn = event.target.closest('.reminders-type');

--- a/profile/style.css
+++ b/profile/style.css
@@ -382,6 +382,57 @@
   pointer-events: none;
 }
 
+/* ── выбор времени: кнопка-поле + скрытый нативный инпут (#615) ── */
+.modal__time-button {
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--card-elevated-bg);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.15s ease;
+}
+
+/* Выбранное время — основным цветом текста (плейсхолдер приглушён). */
+.modal__time-button--filled {
+  color: var(--text-color);
+  font-variant-numeric: tabular-nums;
+}
+
+.modal__time-button:active {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.modal__time-button:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+  border-color: transparent;
+}
+
+/*
+  Скрытый нативный input[type=time] — источник значения и владелец пикера.
+  Схлопываем до 1px без display:none, иначе Safari игнорирует showPicker()/focus
+  на невидимом элементе. Не даёт ширины и не влияет на верстку модалки.
+*/
+.modal__time-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  opacity: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  pointer-events: none;
+}
+
 .modal__button--danger {
   background: var(--destructive-color);
   color: var(--accent-contrast);


### PR DESCRIPTION
## Проблема
На iOS нативный `<input type="time">` в модалке «Новое напоминание» (Профиль) рендерился широким и выходил за границы вью — taxqwe/caloriesv2#615.

## Решение
- Заменил инпут на кнопку «Выбрать время»; после выбора на кнопке отображается выбранное время (акцентным цветом вместо приглушённого плейсхолдера).
- Значение по-прежнему хранит скрытый `<input type=time>` (схлопнут до 1px, не `display:none`, чтобы Safari не игнорировал пикер).
- Клик открывает нативный пикер через `showPicker()` с fallback на `focus()+click()`.
- Синхронизация текста кнопки на `change`/`input`, при открытии модалки и смене языка. i18n-ключ `modalTimePlaceholder` (RU/EN). Валидация и лимиты не тронуты.

## Проверка
`node --check` ✓, все `getElementById` резолвятся, паритет RU/EN ✓. Реальный iOS/нативный пикер стоит глянуть вручную.

Ref: taxqwe/caloriesv2#615