### PR TITLE
feat(profile): бенефиты Premium в карточке тарифа

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -32,6 +32,32 @@
           </span>
           <div class="tier__meta" id="tier-meta" hidden><span data-i18n="tierActiveUntil">активен до</span><b id="tier-expires"></b></div>
         </div>
+        <!--
+          Бенефиты Premium (#613). Показываем базовым пользователям как мотивацию
+          к покупке; для premium скрываем в renderTier (они уже всё получили).
+          Виден по умолчанию, чтобы у базовых не мигало до ответа /api/profile.
+        -->
+        <div class="premium-benefits" id="premium-benefits">
+          <h3 class="premium-benefits__title" data-i18n="premiumBenefitsTitle">Что даёт Premium</h3>
+          <ul class="premium-benefits__list">
+            <li class="premium-benefits__item">
+              <svg class="premium-benefits__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/></svg>
+              <span data-i18n="premiumBenefit1">Анализ блюд по фото и аудио</span>
+            </li>
+            <li class="premium-benefits__item">
+              <svg class="premium-benefits__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/></svg>
+              <span data-i18n="premiumBenefit2">Более мощная и точная AI-модель</span>
+            </li>
+            <li class="premium-benefits__item">
+              <svg class="premium-benefits__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/></svg>
+              <span data-i18n="premiumBenefit3">Точнее распознаёт блюда</span>
+            </li>
+            <li class="premium-benefits__item">
+              <svg class="premium-benefits__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/></svg>
+              <span data-i18n="premiumBenefit4">Подсчёт БЖУ (белки/жиры/углеводы)</span>
+            </li>
+          </ul>
+        </div>
         <button type="button" class="premium-cta" id="premium-cta">Купить Premium</button>
         <p class="premium-cta__error" id="premium-cta-error" role="alert" aria-live="polite" hidden></p>
       </section>

--- a/profile/script.js
+++ b/profile/script.js
@@ -68,6 +68,11 @@ const translations = {
     premiumBuy: 'Купить Premium',
     premiumRenew: 'Продлить Premium',
     premiumError: 'Не удалось открыть оплату. Попробуйте позже.',
+    premiumBenefitsTitle: 'Что даёт Premium',
+    premiumBenefit1: 'Анализ блюд по фото и аудио',
+    premiumBenefit2: 'Более мощная и точная AI-модель',
+    premiumBenefit3: 'Точнее распознаёт блюда',
+    premiumBenefit4: 'Подсчёт БЖУ (белки/жиры/углеводы)',
     goalDeficit: 'Цель: дефицит',
     goalSurplus: 'Цель: профицит',
     normEdit: 'Изменить расчёт',
@@ -95,6 +100,11 @@ const translations = {
     premiumBuy: 'Get Premium',
     premiumRenew: 'Renew Premium',
     premiumError: "Couldn't open checkout. Try again later.",
+    premiumBenefitsTitle: 'What Premium gives you',
+    premiumBenefit1: 'Meal analysis from photos and audio',
+    premiumBenefit2: 'More powerful and accurate AI model',
+    premiumBenefit3: 'More precise dish recognition',
+    premiumBenefit4: 'Macronutrient counting (protein/fat/carbs)',
     goalDeficit: 'Goal: deficit',
     goalSurplus: 'Goal: surplus',
     normEdit: 'Edit calculation',
@@ -127,6 +137,7 @@ const els = {
   tierBadgeText: document.getElementById('tier-badge-text'),
   tierMeta: document.getElementById('tier-meta'),
   tierExpires: document.getElementById('tier-expires'),
+  premiumBenefits: document.getElementById('premium-benefits'),
   premiumCta: document.getElementById('premium-cta'),
   premiumCtaError: document.getElementById('premium-cta-error'),
   normValue: document.getElementById('norm-value'),
@@ -241,6 +252,8 @@ function renderTier(subscription) {
   currentTier = tier || null;
   renderPremiumCtaLabel();
   const isPremium = tier && tier !== 'BASIC';
+  // Бенефиты — мотивация к покупке: показываем только не-premium (#613).
+  if (els.premiumBenefits) els.premiumBenefits.hidden = isPremium;
   if (isPremium) {
     els.tierBadge.classList.remove('tier__badge--basic');
     els.tierBadgeIcon.innerHTML = PREMIUM_STAR_SVG;

--- a/profile/style.css
+++ b/profile/style.css
@@ -145,6 +145,46 @@
   text-align: center;
 }
 
+/* ── бенефиты Premium (#613) ── */
+.premium-benefits {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.premium-benefits__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.premium-benefits__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.premium-benefits__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.premium-benefits__icon {
+  flex-shrink: 0;
+  width: 17px;
+  height: 17px;
+  margin-top: 1px;
+  fill: var(--accent-color);
+}
+
 /* ── норма / цель ── */
 .norm {
   display: flex;


### PR DESCRIPTION
## Задача
В Профиле не было списка того, что даёт Premium — taxqwe/caloriesv2#613.

## Решение
- В карточку «Тариф» добавлен блок «Что даёт Premium» / «What Premium gives you»: 4 пункта с иконками (анализ фото/аудио, более мощная/точная AI-модель, распознавание блюд, подсчёт БЖУ). Формулировки — из `premiumInfoMessage` бота.
- Видимость: базовым пользователям показывается (мотивация к покупке), premium — скрывается в `renderTier`. По умолчанию виден в HTML, чтобы не мигало до `/api/profile`.
- i18n RU/EN, семантический `<ul>/<li>`, иконки `aria-hidden`.

## Проверка
`node --check` ✓, все `getElementById` резолвятся, паритет RU/EN (5 ключей × ru+en) ✓.

Ref: taxqwe/caloriesv2#613