### PR TITLE
fix(profile): пикер времени не открывался тапом на iOS (follow-up к #58)

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -118,14 +118,18 @@
         <span class="modal__label" id="reminders-modal-time-label" data-rem-i18n="modalTimeLabel">Время</span>
         <!--
           Нативный input[type=time] под iOS рендерится широким и вылезал за
-          границы модалки (#615). Прячем его как источник значения для нативного
-          пикера, а видимый контрол — кнопка, открывающая пикер по клику.
+          границы модалки (#615). Оставляем настоящий input интерактивным, но
+          прозрачным оверлеем поверх видимой кнопки-поля: тап попадает прямо в
+          input, и iOS сам открывает нативный барабан (программный showPicker()
+          на скрытом input под iOS не срабатывает). Текст кнопки — только показ
+          выбранного значения / плейсхолдера, поверх контейнер клипует overflow.
         -->
-        <button type="button" class="modal__time-button" id="reminders-modal-time-button"
-                aria-labelledby="reminders-modal-time-label"
-                data-rem-i18n="modalTimePlaceholder">Выбрать время</button>
-        <input class="modal__time-input" id="reminders-modal-time" type="time" required
-               tabindex="-1" aria-hidden="true">
+        <div class="modal__time-picker">
+          <span class="modal__time-button" id="reminders-modal-time-button"
+                data-rem-i18n="modalTimePlaceholder" aria-hidden="true">Выбрать время</span>
+          <input class="modal__time-input" id="reminders-modal-time" type="time" required
+                 aria-labelledby="reminders-modal-time-label">
+        </div>
       </div>
 
       <div class="modal__field">

--- a/profile/reminders.js
+++ b/profile/reminders.js
@@ -308,26 +308,6 @@
     }
   }
 
-  // Открываем нативный пикер времени. showPicker() — предпочтительный путь
-  // (Safari iOS 16+/современные браузеры); в старых или при ошибке падаем на
-  // focus()+click(), чтобы барабан времени всё равно поднялся.
-  function openTimePicker() {
-    try {
-      if (typeof els.modalTime.showPicker === 'function') {
-        els.modalTime.showPicker();
-        return;
-      }
-    } catch (_) {
-      void 0;
-    }
-    try {
-      els.modalTime.focus();
-      els.modalTime.click();
-    } catch (_) {
-      void 0;
-    }
-  }
-
   function clearModalError() {
     els.modalError.hidden = true;
     els.modalError.textContent = '';
@@ -549,13 +529,13 @@
   els.add.addEventListener('click', handleAddClick);
   els.modalForm.addEventListener('submit', handleModalSubmit);
 
-  // Кнопка открывает нативный пикер; выбранное значение прилетает событиями
-  // change/input на скрытом инпуте и отражается на тексте кнопки.
-  els.modalTimeButton.addEventListener('click', () => {
+  // Тап по полю попадает прямо в прозрачный input[type=time] сверху — iOS сам
+  // открывает нативный барабан. Выбранное значение прилетает событиями
+  // change/input и отражается на тексте кнопки-поля.
+  els.modalTime.addEventListener('change', () => {
     clearModalError();
-    openTimePicker();
+    syncTimeButton();
   });
-  els.modalTime.addEventListener('change', syncTimeButton);
   els.modalTime.addEventListener('input', syncTimeButton);
 
   els.modalTypes.addEventListener('click', (event) => {

--- a/profile/style.css
+++ b/profile/style.css
@@ -422,8 +422,21 @@
   pointer-events: none;
 }
 
-/* ── выбор времени: кнопка-поле + скрытый нативный инпут (#615) ── */
+/* ── выбор времени: кнопка-поле + прозрачный нативный инпут-оверлей (#615) ── */
+/*
+  Контейнер задаёт габариты поля и клипует нативный контрол, чтобы его широкий
+  рендер под iOS не вылезал за границы модалки.
+*/
+.modal__time-picker {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+}
+
+/* Видимая часть — только показ значения/плейсхолдера. Тапы проходят сквозь
+   неё на input, лежащий сверху (pointer-events: none). */
 .modal__time-button {
+  display: block;
   width: 100%;
   box-sizing: border-box;
   text-align: left;
@@ -435,7 +448,7 @@
   font-family: inherit;
   font-size: 16px;
   font-weight: 500;
-  cursor: pointer;
+  pointer-events: none;
   transition: border-color 0.2s ease, background-color 0.15s ease;
 }
 
@@ -445,32 +458,35 @@
   font-variant-numeric: tabular-nums;
 }
 
-.modal__time-button:active {
-  background: rgba(255, 255, 255, 0.06);
+/*
+  Настоящий input[type=time] — прозрачный оверлей на всю площадь поля. Тап
+  попадает прямо в него, iOS открывает нативный барабан без JS. opacity:0
+  прячет широкий нативный рендер; контейнер обрезает возможный overflow.
+*/
+.modal__time-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  opacity: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
 }
 
-.modal__time-button:focus-visible {
+/* Фокус с клавиатуры подсвечиваем на видимой кнопке-поле. */
+.modal__time-picker:focus-within .modal__time-button {
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;
   border-color: transparent;
 }
 
-/*
-  Скрытый нативный input[type=time] — источник значения и владелец пикера.
-  Схлопываем до 1px без display:none, иначе Safari игнорирует showPicker()/focus
-  на невидимом элементе. Не даёт ширины и не влияет на верстку модалки.
-*/
-.modal__time-input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: 0;
-  border: 0;
-  opacity: 0;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  pointer-events: none;
+.modal__time-picker:active .modal__time-button {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .modal__button--danger {


### PR DESCRIPTION
Follow-up к уже смерженному #58: там поле выбора времени **не реагировало на тап на iOS**.

## Причина
Реализация из #58 прятала `<input type=time>` (1px, `pointer-events:none`) и открывала пикер программно через `showPicker()`/`focus()`. На iOS со скрытого инпута это не срабатывает — тап по кнопке ничего не делал.

## Решение
Канонический iOS-паттерн: настоящий `<input type=time>` — прозрачный оверлей на всю площадь поля (`inset:0`, `opacity:0`), кнопка-поле снизу чисто визуальная (`pointer-events:none`, показывает выбранное время/плейсхолдер). Тап попадает прямо в инпут → iOS открывает нативный барабан без JS. Контейнер клипует широкий нативный рендер, overflow отсутствует.

## Проверка (реальный CSS в браузере)
- `elementFromPoint` в центре поля → это сам `input` (тап доходит);
- горизонтальный overflow = 0;
- текст поля обновляется `Выбрать время` → `09:30`.

Живьём OS-барабан открывается только на устройстве, но тап-таргет теперь — видимый (не `display:none`) time-инпут, для него открытие пикера по тапу — гарантированное поведение iOS.

Ref: taxqwe/caloriesv2#615