### PR TITLE
fix: слать таймзону браузера с bmr/profile/edit на /api/tz

### DIFF
--- a/bmr/index.html
+++ b/bmr/index.html
@@ -108,6 +108,7 @@
   </div>
 
   <script src="../config.js"></script>
+  <script src="../timezone-sync.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/edit/index.html
+++ b/edit/index.html
@@ -196,6 +196,7 @@
   </div>
   
   <script src="../config.js"></script>
+  <script src="../timezone-sync.js"></script>
   <script src="main.js"></script>
   <script src="script.js" defer></script>
 </body>

--- a/history/index.html
+++ b/history/index.html
@@ -121,6 +121,7 @@
   </template>
 
   <script src="../config.js"></script>
+  <script src="../timezone-sync.js"></script>
   <script src="localization.js"></script>
   <script type="module" src="script.js"></script>
 </body>

--- a/profile/index.html
+++ b/profile/index.html
@@ -208,6 +208,7 @@
   </nav>
 
   <script src="../config.js"></script>
+  <script src="../timezone-sync.js"></script>
   <script src="script.js"></script>
   <script src="reminders.js"></script>
   <script src="digest.js"></script>

--- a/stats/index.html
+++ b/stats/index.html
@@ -580,6 +580,7 @@
   </nav>
 
   <script src="../config.js"></script>
+  <script src="../timezone-sync.js"></script>
   <script src="localization.js"></script>
   <script src="utils.js"></script>
   <script src="block-factory.js"></script>

--- a/timezone-sync.js
+++ b/timezone-sync.js
@@ -1,0 +1,56 @@
+(function () {
+  // Общий хелпер: при открытии любого экрана miniapp сообщает боту таймзону
+  // браузера через POST {API_BASE_URL}/api/tz. Fire-and-forget: не блокирует
+  // рендер, не показывает ошибок пользователю, ничего не делает вне Telegram.
+  // Контекст: taxqwe/caloriesv2#806 — экраны bmr/profile/edit не слали
+  // таймзону вообще, из-за чего часть пользователей получала напоминания
+  // по дефолтной (языковой) таймзоне вместо реальной.
+
+  function getInitData() {
+    try {
+      return window.Telegram?.WebApp?.initData || '';
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function getUserTimezone() {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function getApiBaseUrl() {
+    return window.CaloriesMiniAppConfig?.apiBaseUrl || 'https://caloriesai.duckdns.org';
+  }
+
+  function sendTimezone() {
+    var initData = getInitData();
+    if (!initData) {
+      // Открыто вне Telegram — отправлять нечего и некому.
+      return;
+    }
+
+    var timezone = getUserTimezone();
+    if (!timezone) {
+      // Резолв не удался — молча ничего не отправляем, не гадаем.
+      return;
+    }
+
+    try {
+      fetch(getApiBaseUrl() + '/api/tz', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ initData: initData, timezone: timezone })
+      }).catch(function () {
+        // Сетевая ошибка/не-2xx — тихо игнорируем, экран не должен пострадать.
+      });
+    } catch (error) {
+      // На случай окружений без fetch — тоже тихо игнорируем.
+    }
+  }
+
+  sendTimezone();
+})();


### PR DESCRIPTION
## Проблема

Таймзона браузера долетала до бота только с двух экранов — `stats/script.js` и `history/script.js`, которые попутно шлют её в `/api/stats` и history-запросы.

Экраны **bmr**, **profile**, **edit** таймзону не передавали вообще. Из-за этого пользователь, прошедший только BMR-онбординг и ни разу не открывавший статистику/историю, оставался у бота на дефолтной таймзоне по языку (для en/pt — `Europe/London`) и получал напоминания не по своему локальному времени. Отдельно абсурдно, что экран `profile/reminders.js`, где юзер выставляет время напоминания, таймзону не передавал вовсе.

Подробности и аудит — taxqwe/caloriesv2#806.

## Фикс

Добавлен общий хелпер `timezone-sync.js` в корне проекта:
- при загрузке страницы шлёт `POST {API_BASE_URL}/api/tz` с телом `{ initData, timezone }`;
- fire-and-forget: не блокирует рендер, ошибки сети/ответа проглатываются тихо (без сообщений пользователю);
- ничего не отправляет, если `tg.initData` пустой (открытие вне Telegram) или если резолв `Intl.DateTimeFormat().resolvedOptions().timeZone` упал — тогда просто ничего не шлём, а не гадаем с фолбэком вроде `UTC`.

Подключён на всех пяти экранах (`bmr`, `profile`, `edit`, `stats`, `history`) сразу после `config.js`. На `stats`/`history` это дублирует их собственную передачу tz в `/api/stats` и history-эндпоинты, но дубль безвреден и приводит все экраны к единому каналу `/api/tz`.

## Как проверить

1. Открыть в Telegram miniapp экран `/bmr`, `/profile` или `/edit`.
2. В devtools/сетевых логах убедиться, что улетает `POST /api/tz` с корректным `timezone` (например `Europe/Moscow`) и непустым `initData`.
3. Открыть страницу вне Telegram (без `tg.initData`) — запрос не должен уходить, ошибок в консоли быть не должно.

Примечание: приёмная сторона (`/api/tz` в боте) чинится параллельно в `taxqwe/caloriesv2`, поэтому пока PR туда не смёржен, этот вызов безвреден, но реального эффекта на таймзону пользователя не даёт — это ожидаемо, шипаем парой.

## Скоуп

Только фронт miniapp: новый файл `timezone-sync.js` + по одной строке `<script>` в пяти `index.html`. Существующая логика передачи tz в `stats`/`history` не тронута.

Refs taxqwe/caloriesv2#806