### PR TITLE
feat(profile): показывать теги предпочтений в карточке «Норма и цель»

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -69,6 +69,10 @@
           <div class="norm__value" id="norm-value">— <span class="unit" data-i18n="unit">ккал/день</span></div>
           <div class="norm__meta" id="norm-meta"><span data-i18n="expend">дневной расход</span> <b id="norm-tdee">—</b></div>
           <span class="goal-chip" id="goal-chip" hidden></span>
+          <div class="norm__prefs" id="prefs-block" hidden>
+            <span class="norm__prefs-title" data-i18n="preferencesTitle">Предпочтения</span>
+            <div class="pref-chips" id="pref-chips"></div>
+          </div>
         </div>
         <p class="profile__hint" id="norm-empty" data-i18n="normEmpty" hidden>Норма ещё не рассчитана. Рассчитайте дневную норму калорий.</p>
         <a class="btn-secondary" id="norm-edit-link" href="../bmr/index.html?mode=edit">

--- a/profile/script.js
+++ b/profile/script.js
@@ -81,6 +81,15 @@ const translations = {
     premiumBenefit4: 'Подсчёт БЖУ (белки/жиры/углеводы)',
     goalDeficit: 'Цель: дефицит',
     goalSurplus: 'Цель: профицит',
+    preferencesTitle: 'Предпочтения',
+    preferences: {
+      more_protein: 'Белок',
+      less_sugar: 'Сахар',
+      more_veggies: 'Овощи',
+      low_carb: 'Углеводы',
+      more_water: 'Вода',
+      less_fat: 'Жиры'
+    },
     normEdit: 'Изменить расчёт',
     normCalc: 'Рассчитать норму',
     normEmpty: 'Норма ещё не рассчитана. Рассчитайте дневную норму калорий.',
@@ -118,6 +127,15 @@ const translations = {
     premiumBenefit4: 'Macronutrient counting (protein/fat/carbs)',
     goalDeficit: 'Goal: deficit',
     goalSurplus: 'Goal: surplus',
+    preferencesTitle: 'Preferences',
+    preferences: {
+      more_protein: 'Protein',
+      less_sugar: 'Sugar',
+      more_veggies: 'Veggies',
+      low_carb: 'Carbs',
+      more_water: 'Water',
+      less_fat: 'Fat'
+    },
     normEdit: 'Edit calculation',
     normCalc: 'Calculate norm',
     normEmpty: 'Norm not calculated yet. Calculate your daily calorie norm.',
@@ -155,6 +173,8 @@ const els = {
   normMeta: document.getElementById('norm-meta'),
   normTdee: document.getElementById('norm-tdee'),
   goalChip: document.getElementById('goal-chip'),
+  prefsBlock: document.getElementById('prefs-block'),
+  prefChips: document.getElementById('pref-chips'),
   normEmpty: document.getElementById('norm-empty'),
   normEditLink: document.getElementById('norm-edit-link'),
   normEditLabel: document.getElementById('norm-edit-label'),
@@ -162,6 +182,15 @@ const els = {
   notificationsValue: document.getElementById('notifications-value'),
   languageValue: document.getElementById('language-value')
 };
+
+const PREFERENCE_DEFS = [
+  { key: 'more_protein', emoji: '🥩', dir: 'up' },
+  { key: 'less_sugar', emoji: '🍬', dir: 'down' },
+  { key: 'more_veggies', emoji: '🥗', dir: 'up' },
+  { key: 'low_carb', emoji: '🌾', dir: 'down' },
+  { key: 'more_water', emoji: '💧', dir: 'up' },
+  { key: 'less_fat', emoji: '🧈', dir: 'down' }
+];
 
 const PREMIUM_STAR_SVG =
   '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2l2.4 4.9 5.4.8-3.9 3.8.9 5.4-4.8-2.5-4.8 2.5.9-5.4L4.2 7.7l5.4-.8z"/></svg>';
@@ -333,6 +362,36 @@ function renderNorm(norm, goal) {
   }
 }
 
+function renderPreferences(preferences) {
+  if (!els.prefsBlock || !els.prefChips) return;
+  const allowed = Array.isArray(preferences)
+    ? PREFERENCE_DEFS.filter((def) => preferences.includes(def.key))
+    : [];
+
+  els.prefChips.innerHTML = '';
+  if (!allowed.length) {
+    els.prefsBlock.hidden = true;
+    return;
+  }
+
+  const labels = t().preferences || {};
+  allowed.forEach((def) => {
+    const chip = document.createElement('span');
+    chip.className = 'pref-chip';
+
+    const emoji = document.createElement('span');
+    emoji.className = 'pref-chip__emoji';
+    emoji.textContent = def.emoji;
+
+    const label = document.createElement('span');
+    label.textContent = (labels[def.key] || def.key) + (def.dir === 'down' ? ' ↓' : ' ↑');
+
+    chip.append(emoji, label);
+    els.prefChips.appendChild(chip);
+  });
+  els.prefsBlock.hidden = false;
+}
+
 // Сводка для строки «Уведомления»: сколько слотов напоминаний настроено.
 // Когда слотов нет — показываем состояние еженедельного отчёта, чтобы строка
 // не выглядела пустой у тех, кто напоминаниями не пользуется.
@@ -467,6 +526,7 @@ function render(profile) {
   applyNavLang();
   renderTier(profile?.subscription);
   renderNorm(profile?.norm, profile?.goal);
+  renderPreferences(profile?.preferences);
   renderNotifications(profile);
   renderMisc(profile?.locale);
   els.status.hidden = true;

--- a/profile/style.css
+++ b/profile/style.css
@@ -232,6 +232,44 @@
   border-radius: 999px;
 }
 
+.norm__prefs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.norm__prefs-title {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.pref-chips {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 6px;
+}
+
+.pref-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--card-elevated-bg);
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.pref-chip__emoji {
+  font-size: 13px;
+  line-height: 1;
+}
+
 .btn-secondary {
   background: var(--card-elevated-bg);
   border: 1px solid var(--border-color);


### PR DESCRIPTION
Раньше на Профиле было видно только цель (дефицит/профицит и процент), а выбранные диетические предпочтения — только если провалиться в `bmr/?mode=edit`. Теперь они показываются прямо в карточке «Норма и цель».

## Что сделано

- `profile/index.html` — блок `#prefs-block` с подписью «Предпочтения» и контейнером чипсов под чипом цели.
- `profile/script.js` — `PREFERENCE_DEFS` (тот же порядок, эмодзи и направление, что в `bmr/main.js`), `renderPreferences()` и вызов из `render()`. Ключи вне канонического списка отфильтровываются, при пустом списке блок скрыт.
- `profile/style.css` — `.pref-chip` как уменьшенная версия чипса из BMR (12px, в размер `.goal-chip`), на общих CSS-переменных, так что тема подхватывается сама.
- Локализация RU + EN, как и остальной экран Профиля.

Бэкенд менять не пришлось: `/api/profile` уже отдаёт `preferences: List<String>` — мини-ап просто их игнорировал.

## Проверка

Локальный `python3 -m http.server` + Playwright с замоканным `render(...)`: светлая и тёмная тема, RU и EN, 4 и 6 тегов (перенос в две строки), пустой список — блок скрывается.

Чипсы на Профиле read-only: редактирование остаётся на экране BMR/Goal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1xovV28GaZTwoPmonCcGZ)_